### PR TITLE
Replace WIP with a better message.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,2 +1,4 @@
 <meta http-equiv="refresh" content="0; url=./latest" />
-<h1>WIP</h1>
+<h1>Astarte Documentation</h1>
+
+<p>Redirecting to <a href="./latest/index.html">latest Astarte documentation</a>.</p>


### PR DESCRIPTION
When opening astarte documentation "WIP" is shortly displayed, change it
with something better.